### PR TITLE
Include metadata about replication keys

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -198,20 +198,13 @@ def schema_for_column(c):
 def create_column_metadata(cols):
     mdata = metadata.new()
     mdata = metadata.write(mdata, (), 'selected-by-default', False)
+    valid_rep_keys = []
 
     for c in cols:
-        valid_rep_keys = [c['name'] for c in cols
-                          if c['type'] == 'timestamp'
-                          or c['type'] == 'timestamptz']
-        schema = schema_for_column(c)
+        if c['type'] in DATETIME_TYPES:
+            valid_rep_keys.append(c['name'])
 
-        if valid_rep_keys:
-            mdata = metadata.write(mdata, (), 'valid-replication-keys',
-                                   valid_rep_keys)
-        else:
-            mdata = metadata.write(mdata, (), 'forced-replication-method', {
-                'replication-method': 'FULL_TABLE',
-                'reason': 'No replication keys found from table'})
+        schema = schema_for_column(c)
 
         mdata = metadata.write(mdata,
                                ('properties', c['name']),
@@ -221,6 +214,13 @@ def create_column_metadata(cols):
                                ('properties', c['name']),
                                'sql-datatype',
                                c['type'].lower())
+    if valid_rep_keys:
+        mdata = metadata.write(mdata, (), 'valid-replication-keys',
+                               valid_rep_keys)
+    else:
+        mdata = metadata.write(mdata, (), 'forced-replication-method', {
+            'replication-method': 'FULL_TABLE',
+            'reason': 'No replication keys found from table'})
 
     return metadata.to_list(mdata)
 

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -60,7 +60,9 @@ BYTES_FOR_INTEGER_TYPE = {
 
 FLOAT_TYPES = {'float', 'float4', 'float8'}
 
-DATETIME_TYPES = {'timestamp', 'timestamptz', 'date',
+DATE_TYPES = {'date'}
+
+DATETIME_TYPES = {'timestamp', 'timestamptz',
                   'timestamp without time zone', 'timestamp with time zone'}
 
 
@@ -176,6 +178,10 @@ def schema_for_column(c):
     elif column_type in DATETIME_TYPES:
         result.type = 'string'
         result.format = 'date-time'
+
+    elif column_type in DATE_TYPES:
+        result.type = 'string'
+        result.format = 'date'
 
     else:
         result = Schema(None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,8 @@ def expected_catalog_from_db():
          'stream': 'table1',
          'metadata': [
              {'breadcrumb': (),
-              'metadata': {'selected-by-default': False}},
+              'metadata': {'selected-by-default': False,
+                           'valid-replication-keys': ['col1']}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'int2'}},
@@ -134,7 +135,8 @@ def expected_catalog_from_db():
          'stream': 'table2',
          'metadata': [
              {'breadcrumb': (),
-              'metadata': {'selected-by-default': False}},
+              'metadata': {'selected-by-default': False,
+                           'valid-replication-keys': ['col1', 'col2']}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'int4'}},
@@ -157,7 +159,10 @@ def expected_catalog_from_db():
          'stream': 'view1',
          'metadata': [
              {'breadcrumb': (),
-              'metadata': {'selected-by-default': False}},
+              'metadata': {'selected-by-default': False,
+                           'forced-replication-method': {
+                              'replication-method': 'FULL_TABLE',
+                              'reason': 'No key properties found for table'}}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'varchar'}},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,8 @@ def column_specs_cursor():
         result = [('table1', 1, 'col1', 'int2', 'NO'),
                   ('table1', 2, 'col2', 'float8', 'YES'),
                   ('table1', 3, 'col3', 'timestamptz', 'NO'),
+                  ('table1', 4, 'col4', 'timestamp', 'NO'),
+                  ('table1', 5, 'col5', 'timestamp with time zone', 'NO'),
                   ('table2', 1, 'col1', 'int4', 'NO'),
                   ('table2', 2, 'col2', 'bool', 'YES'),
                   ('view1', 1, 'col1', 'varchar', 'NO'),
@@ -97,6 +99,14 @@ def expected_catalog_from_db():
                  'col3': {
                      'inclusion': 'available',
                      'format': 'date-time',
+                     'type': 'string'},
+                 'col4': {
+                     'inclusion': 'available',
+                     'format': 'date-time',
+                     'type': 'string'},
+                 'col5': {
+                     'inclusion': 'available',
+                     'format': 'date-time',
                      'type': 'string'}},
              'type': 'object'},
          'is_view': False,
@@ -104,7 +114,8 @@ def expected_catalog_from_db():
          'metadata': [
              {'breadcrumb': (),
               'metadata': {'selected-by-default': False,
-                           'valid-replication-keys': ['col3']}},
+                           'valid-replication-keys': [
+                               'col3', 'col4', 'col5']}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'int2'}},
@@ -113,7 +124,13 @@ def expected_catalog_from_db():
                            'sql-datatype': 'float8'}},
              {'breadcrumb': ('properties', 'col3'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'timestamptz'}}
+                           'sql-datatype': 'timestamptz'}},
+             {'breadcrumb': ('properties', 'col4'),
+              'metadata': {'selected-by-default': True,
+                           'sql-datatype': 'timestamp'}},
+             {'breadcrumb': ('properties', 'col5'),
+              'metadata': {'selected-by-default': True,
+                           'sql-datatype': 'timestamp with time zone'}}
          ]},
         {'tap_stream_id': 'test-db.public.table2',
          'database_name': 'test-db',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,7 +104,7 @@ def expected_catalog_from_db():
          'metadata': [
              {'breadcrumb': (),
               'metadata': {'selected-by-default': False,
-                           'valid-replication-keys': ['col1']}},
+                           'valid-replication-keys': ['col3']}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'int2'}},
@@ -136,7 +136,10 @@ def expected_catalog_from_db():
          'metadata': [
              {'breadcrumb': (),
               'metadata': {'selected-by-default': False,
-                           'valid-replication-keys': ['col1', 'col2']}},
+                           'forced-replication-method': {
+                            'replication-method': 'FULL_TABLE',
+                            'reason': 'No replication keys found from table'
+                           }}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'int4'}},
@@ -161,8 +164,9 @@ def expected_catalog_from_db():
              {'breadcrumb': (),
               'metadata': {'selected-by-default': False,
                            'forced-replication-method': {
-                              'replication-method': 'FULL_TABLE',
-                              'reason': 'No key properties found for table'}}},
+                            'replication-method': 'FULL_TABLE',
+                            'reason': 'No replication keys found from table'
+                           }}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'varchar'}},

--- a/tests/tap_redshift/test_tap_redshift.py
+++ b/tests/tap_redshift/test_tap_redshift.py
@@ -191,7 +191,6 @@ class TestRedShiftTap(object):
 
             actual_metadata = metadata.to_map(actual_entry.metadata)
             expected_metadata = metadata.to_map(expected_entry.metadata)
-
             for bcrumb, actual_mdata in actual_metadata.items():
                 for mdata_key, actual_value in actual_mdata.items():
                     assert_that(
@@ -207,15 +206,19 @@ class TestRedShiftTap(object):
                  'nullable': 'YES'},
                 {'pos': 3, 'name': 'col3', 'type': 'timestamptz',
                  'nullable': 'NO'}]
+        key_properties = ['col1']
         expected_mdata = metadata.new()
         metadata.write(expected_mdata, (), 'selected-by-default', False)
+        metadata.write(expected_mdata, (), 'valid-replication-keys',
+                       key_properties)
         for col in cols:
             metadata.write(expected_mdata, (
                 'properties', col['name']), 'selected-by-default', True)
             metadata.write(expected_mdata, (
                 'properties', col['name']), 'sql-datatype', col['type'])
 
-        actual_mdata = tap_redshift.create_column_metadata(cols)
+        actual_mdata = tap_redshift.create_column_metadata(cols,
+                                                           key_properties)
         assert_that(actual_mdata, equal_to(metadata.to_list(expected_mdata)))
 
     def test_type_int4(self):

--- a/tests/tap_redshift/test_tap_redshift.py
+++ b/tests/tap_redshift/test_tap_redshift.py
@@ -61,6 +61,12 @@ sample_db_data = {
         {
             'type': 'date',
             'pos': 6,
+            'name': 'date_expired',
+            'nullable': 'YES'
+        },
+        {
+            'type': 'timestamp',
+            'pos': 7,
             'name': 'date_created',
             'nullable': 'YES'
         }
@@ -111,12 +117,27 @@ expected_result = {
                             'null',
                             'string'
                         ],
+                        'format': 'date',
+                        'inclusion': 'available'
+                    },
+                    'created_at': {
+                        'type': [
+                            'null',
+                            'string'
+                        ],
                         'format': 'date-time',
                         'inclusion': 'available'
                     }
                 },
             },
             'metadata': [
+                {
+                    'metadata': {
+                        'selected-by-default': False,
+                        'valid-replication-keys': ['created_at']
+                    },
+                    'breadcrumb': ()
+                },
                 {
                     'metadata': {
                         'sql-datatype': 'int4',
@@ -154,16 +175,22 @@ expected_result = {
                 },
                 {
                     'metadata': {
-                        'sql-datatype': 'timestamptz',
+                        'sql-datatype': 'date',
                         'selected-by-default': True
                     },
                     'breadcrumb': ['properties', 'expires_at']
+                },
+                {
+                    'metadata': {
+                        'sql-datatype': 'timestamptz',
+                        'selected-by-default': True
+                    },
+                    'breadcrumb': ['properties', 'created_at']
                 },
             ],
             'key_properties': [
                 'id'
             ],
-            'is_view': False,
             'table_name': 'fake name',
             'stream': 'fake stream',
             'tap_stream_id': 'FakeDB-fake name'
@@ -261,5 +288,26 @@ class TestRedShiftTap(object):
         stream_schema = expected_result['streams'][0]
         expected_schema = stream_schema['schema']['properties']['expires_at']
         assert_that(column_schema, equal_to(expected_schema))
+
+    def test_type_date_time(self):
+        col = sample_db_data['columns'][6]
+        column_schema = tap_redshift.schema_for_column(col).to_dict()
+        stream_schema = expected_result['streams'][0]
+        expected_schema = stream_schema['schema']['properties']['created_at']
+        assert_that(column_schema, equal_to(expected_schema))
+
+    def test_valid_rep_keys(self, discovery_conn, expected_catalog_from_db):
+        actual_catalog = tap_redshift.discover_catalog(discovery_conn,
+                                                       'public')
+        for i, actual_entry in enumerate(actual_catalog.streams):
+            expected_entry = expected_catalog_from_db.streams[i]
+            actual_metadata = metadata.to_map(actual_entry.metadata)
+            expected_metadata = metadata.to_map(expected_entry.metadata)
+            actual_valid_rep_keys = metadata.get(
+                actual_metadata, (), 'valid-replication-keys')
+            expected_valid_rep_keys = metadata.get(
+                expected_metadata, (), 'valid-replication-keys')
+            assert_that(actual_valid_rep_keys,
+                        equal_to(expected_valid_rep_keys))
 
         # TODO write tests for full and incremental sync

--- a/tests/tap_redshift/test_tap_redshift.py
+++ b/tests/tap_redshift/test_tap_redshift.py
@@ -206,19 +206,18 @@ class TestRedShiftTap(object):
                  'nullable': 'YES'},
                 {'pos': 3, 'name': 'col3', 'type': 'timestamptz',
                  'nullable': 'NO'}]
-        key_properties = ['col1']
         expected_mdata = metadata.new()
         metadata.write(expected_mdata, (), 'selected-by-default', False)
-        metadata.write(expected_mdata, (), 'valid-replication-keys',
-                       key_properties)
         for col in cols:
+            metadata.write(expected_mdata, (),
+                           'valid-replication-keys',
+                           ['col3'])
             metadata.write(expected_mdata, (
                 'properties', col['name']), 'selected-by-default', True)
             metadata.write(expected_mdata, (
                 'properties', col['name']), 'sql-datatype', col['type'])
 
-        actual_mdata = tap_redshift.create_column_metadata(cols,
-                                                           key_properties)
+        actual_mdata = tap_redshift.create_column_metadata(cols)
         assert_that(actual_mdata, equal_to(metadata.to_list(expected_mdata)))
 
     def test_type_int4(self):


### PR DESCRIPTION
Resolves issue #11 - Uses fields of data-types `timestamp or timestamptz` in metadata for valid replication keys.