### PR TITLE
Add start date config

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -291,9 +291,11 @@ def sync_table(connection, catalog_entry, state):
         params = {}
         start_date = str(datetime.datetime.strptime(
             CONFIG.get('start_date'), '%Y-%m-%dT%H:%M:%SZ'))
-        replication_key_value = singer.get_bookmark(state,
-                                                    tap_stream_id,
-                                                    'replication_key_value') or start_date
+        replication_key_value = singer.get_bookmark(
+                                    state,
+                                    tap_stream_id,
+                                    'replication_key_value'
+                                ) or start_date
         replication_key = singer.get_bookmark(state,
                                               tap_stream_id,
                                               'replication_key')

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -296,23 +296,19 @@ def sync_table(connection, catalog_entry, state):
             formatted_start_date = str(datetime.datetime.strptime(
                 start_date, '%Y-%m-%dT%H:%M:%SZ'))
 
-        replication_key_value = singer.get_bookmark(
-                                    state,
-                                    tap_stream_id,
-                                    'replication_key_value'
-                                ) or formatted_start_date
         replication_key = singer.get_bookmark(state,
                                               tap_stream_id,
                                               'replication_key')
-
+        replication_key_value = None
         bookmark_is_empty = state.get('bookmarks', {}).get(
             tap_stream_id) is None
-
         stream_version = get_stream_version(tap_stream_id, state)
-        state = singer.write_bookmark(state,
-                                      tap_stream_id,
-                                      'version',
-                                      stream_version)
+        state = singer.write_bookmark(
+            state,
+            tap_stream_id,
+            'version',
+            stream_version
+        )
         activate_version_message = singer.ActivateVersionMessage(
             stream=catalog_entry.stream,
             version=stream_version
@@ -326,6 +322,13 @@ def sync_table(connection, catalog_entry, state):
         # version.
         if replication_key or bookmark_is_empty:
             yield activate_version_message
+
+        if replication_key:
+            replication_key_value = singer.get_bookmark(
+                state,
+                tap_stream_id,
+                'replication_key_value'
+            ) or formatted_start_date
 
         if replication_key_value is not None:
             entry_schema = catalog_entry.schema

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -274,6 +274,8 @@ def row_to_record(catalog_entry, version, row, columns, time_extracted):
 
 def sync_table(connection, catalog_entry, state):
     columns = list(catalog_entry.schema.properties.keys())
+    start_date = CONFIG.get('start_date')
+    formatted_start_date = None
 
     if not columns:
         LOGGER.warning(
@@ -289,13 +291,16 @@ def sync_table(connection, catalog_entry, state):
             ','.join(columns),
             catalog_entry.table)
         params = {}
-        start_date = str(datetime.datetime.strptime(
-            CONFIG.get('start_date'), '%Y-%m-%dT%H:%M:%SZ'))
+
+        if start_date is not None:
+            formatted_start_date = str(datetime.datetime.strptime(
+                start_date, '%Y-%m-%dT%H:%M:%SZ'))
+
         replication_key_value = singer.get_bookmark(
                                     state,
                                     tap_stream_id,
                                     'replication_key_value'
-                                ) or start_date
+                                ) or formatted_start_date
         replication_key = singer.get_bookmark(state,
                                               tap_stream_id,
                                               'replication_key')

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -66,6 +66,8 @@ DATE_TYPES = {'date'}
 DATETIME_TYPES = {'timestamp', 'timestamptz',
                   'timestamp without time zone', 'timestamp with time zone'}
 
+CONFIG = {}
+
 
 def discover_catalog(conn, db_schema):
     '''Returns a Catalog describing the structure of the database.'''
@@ -287,10 +289,11 @@ def sync_table(connection, catalog_entry, state):
             ','.join(columns),
             catalog_entry.table)
         params = {}
-
+        start_date = str(datetime.datetime.strptime(
+            CONFIG.get('start_date'), '%Y-%m-%dT%H:%M:%SZ'))
         replication_key_value = singer.get_bookmark(state,
                                                     tap_stream_id,
-                                                    'replication_key_value')
+                                                    'replication_key_value') or start_date
         replication_key = singer.get_bookmark(state,
                                               tap_stream_id,
                                               'replication_key')
@@ -462,6 +465,7 @@ def build_state(raw_state, catalog):
 
 def main_impl():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
+    CONFIG.update(args.config)
     connection = open_connection(args.config)
     db_schema = args.config.get('schema', 'public')
     if args.discover:


### PR DESCRIPTION
@rflprr - This PR requires `start_date` in the config and uses the `start_date` as `replication_key_value` on full sync/first run. Help take a look.