### PR TITLE
Bug: tables with special chars fail

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -289,7 +289,7 @@ def sync_table(connection, catalog_entry, state):
         columns = ['"{}"'.format(c) for c in columns]
         select = 'SELECT {} FROM {}'.format(
             ','.join(columns),
-            catalog_entry.table)
+            '"{}"'.format(catalog_entry.table))
         params = {}
 
         if start_date is not None:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -287,9 +287,11 @@ def sync_table(connection, catalog_entry, state):
     LOGGER.info('Beginning sync for {} table'.format(tap_stream_id))
     with connection.cursor() as cursor:
         columns = ['"{}"'.format(c) for c in columns]
-        select = 'SELECT {} FROM {}'.format(
+        schema, table = catalog_entry.table.split('.')
+        select = 'SELECT {} FROM {}.{}'.format(
             ','.join(columns),
-            '"{}"'.format(catalog_entry.table))
+            '"{}"'.format(schema),
+            '"{}"'.format(table))
         params = {}
 
         if start_date is not None:


### PR DESCRIPTION
A table named `facebook-ads` will lead to an error. Here we're quoting the schema and the table name to resolve this.