### PR TITLE
Add key properties to SCHEMA message; Migrate fields to metadata

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,11 +75,7 @@ Example:
                 "tap_stream_id": "sample-dbname.public.sample-name",
                 "stream": "sample-stream",
                 "database_name": "sample-dbname",
-                "table_name": "public.sample-name",
-                "is_view": false,
-                "key_properties": [
-                    "id"
-                ],
+                "table_name": "public.sample-name"
                 "schema": {
                     "properties": {
                         "id": {
@@ -113,14 +109,21 @@ Example:
                     {
                         "metadata": {
                             "selected-by-default": false,
-                            "selected": true
+                            "selected": true,
+                            "is-view": false,
+                            "table-key-properties": ["id"],
+                            "schema-name": "sample-stream",
+                            "valid-replication-keys": [
+                                "updated_at"
+                            ]
                         },
                         "breadcrumb": [],
                     },
                     {
                         "metadata": {
                             "selected-by-default": true,
-                            "sql-datatype": "int2"
+                            "sql-datatype": "int2",
+                            "inclusion": "automatic"
                         },
                         "breadcrumb": [
                             "properties",
@@ -130,7 +133,8 @@ Example:
                     {
                         "metadata": {
                             "selected-by-default": true,
-                            "sql-datatype": "varchar"
+                            "sql-datatype": "varchar",
+                            "inclusion": "available"
                         },
                         "breadcrumb": [
                             "properties",
@@ -140,7 +144,8 @@ Example:
                     {
                         "metadata": {
                             "selected-by-default": true,
-                            "sql-datatype": "datetime"
+                            "sql-datatype": "datetime",
+                            "inclusion": "available",
                         },
                         "breadcrumb": [
                             "properties",
@@ -171,7 +176,8 @@ Example:
         {
             "breadcrumb": [],
             "metadata": {
-                "selected-by-default": false
+                "selected-by-default": false,
+                ...
             }
         }
     ]
@@ -187,7 +193,8 @@ Example:
             "breadcrumb": [],
             "metadata": {
                 "selected": true,
-                "selected-by-default": false
+                "selected-by-default": false,
+                ...
             }
         }
     ]
@@ -217,21 +224,24 @@ Incremental replication works in conjunction with a state file to only extract n
 time the tap is invoked i.e continue from the last synced data.
 
 To use incremental replication, we need to add the ``replication_method`` and ``replication_key``
-to the top level under each stream in the ``catalog.json`` file.
+to the streams (tables) metadata in the ``catalog.json`` file.
 
 Example:
 
 .. code-block:: json
 
-    {
-        "streams": [
-            {
-                "replication_method": "INCREMENTAL",
-                "replication_key": "updated_at",
+    "metadata": [
+        {
+            "breadcrumb": [],
+            "metadata": {
+                "selected": true,
+                "selected-by-default": false,
+                "replication-method": "INCREMENTAL",
+                "replication-key": "updated_at",
                 ...
             }
-        ]
-    }
+        }
+    ]
 
 We can then invoke the tap again in sync mode. This time the output will have ``STATE`` messages
 that contains a ``replication_key_value`` and ``bookmark`` for data that were extracted.

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -198,7 +198,9 @@ def schema_for_column(c):
     return result
 
 
-def create_column_metadata(db_name, cols, is_view, table_name, key_properties=[]):
+def create_column_metadata(
+        db_name, cols, is_view,
+        table_name, key_properties=[]):
     mdata = metadata.new()
     mdata = metadata.write(mdata, (), 'selected-by-default', False)
     if not is_view:

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -120,10 +120,8 @@ def resolve_catalog(discovered, catalog, state):
             stream=catalog_entry.stream,
             database=catalog_entry.database,
             table=catalog_entry.table,
-            is_view=catalog_entry.is_view,
             schema=schema,
-            replication_key=catalog_entry.replication_key,
-            key_properties=catalog_entry.key_properties
+            metadata=catalog_entry.metadata
         ))
 
     return result

--- a/tap_redshift/resolve.py
+++ b/tap_redshift/resolve.py
@@ -118,7 +118,6 @@ def resolve_catalog(discovered, catalog, state):
         result.streams.append(CatalogEntry(
             tap_stream_id=catalog_entry.tap_stream_id,
             stream=catalog_entry.stream,
-            database=catalog_entry.database,
             table=catalog_entry.table,
             schema=schema,
             metadata=catalog_entry.metadata

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,6 @@ def column_specs_cursor():
 def expected_catalog_from_db():
     return Catalog.from_dict({'streams': [
         {'tap_stream_id': 'test-db.public.table1',
-         'database_name': 'test-db',
          'table_name': 'public.table1',
          'schema': {
              'properties': {
@@ -116,7 +115,8 @@ def expected_catalog_from_db():
                                'col3', 'col4', 'col5'],
                            'table-key-properties': ['col1'],
                            'is-view': False,
-                           'schema-name': 'table1'}},
+                           'schema-name': 'table1',
+                           'database-name': 'test-db'}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'int2',
@@ -139,7 +139,6 @@ def expected_catalog_from_db():
                            'inclusion': 'available'}}
          ]},
         {'tap_stream_id': 'test-db.public.table2',
-         'database_name': 'test-db',
          'table_name': 'public.table2',
          'schema': {
              'properties': {
@@ -163,7 +162,8 @@ def expected_catalog_from_db():
                            },
                            'table-key-properties': ['col1', 'col2'],
                            'is-view': False,
-                           'schema-name': 'table2'}},
+                           'schema-name': 'table2',
+                           'database-name': 'test-db'}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'int4',
@@ -173,7 +173,6 @@ def expected_catalog_from_db():
                            'sql-datatype': 'bool',
                            'inclusion': 'available'}}]},
         {'tap_stream_id': 'test-db.public.view1',
-         'database_name': 'test-db',
          'table_name': 'public.view1',
          'schema': {
              'properties': {
@@ -192,9 +191,10 @@ def expected_catalog_from_db():
                             'replication-method': 'FULL_TABLE',
                             'reason': 'No replication keys found from table'
                            },
-                           'table-key-properties': [],
+                           'view-key-properties': [],
                            'is-view': True,
-                           'schema-name': 'view1'}},
+                           'schema-name': 'view1',
+                           'database-name': 'test-db'}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
                            'sql-datatype': 'varchar',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,6 @@ def expected_catalog_from_db():
         {'tap_stream_id': 'test-db.public.table1',
          'database_name': 'test-db',
          'table_name': 'public.table1',
-         'key_properties': ['col1'],
          'schema': {
              'properties': {
                  'col1': {
@@ -109,33 +108,39 @@ def expected_catalog_from_db():
                      'format': 'date-time',
                      'type': 'string'}},
              'type': 'object'},
-         'is_view': False,
          'stream': 'table1',
          'metadata': [
              {'breadcrumb': (),
               'metadata': {'selected-by-default': False,
                            'valid-replication-keys': [
-                               'col3', 'col4', 'col5']}},
+                               'col3', 'col4', 'col5'],
+                           'table-key-properties': ['col1'],
+                           'is-view': False,
+                           'schema-name': 'table1'}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'int2'}},
+                           'sql-datatype': 'int2',
+                           'inclusion': 'available'}},
              {'breadcrumb': ('properties', 'col2'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'float8'}},
+                           'sql-datatype': 'float8',
+                           'inclusion': 'available'}},
              {'breadcrumb': ('properties', 'col3'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'timestamptz'}},
+                           'sql-datatype': 'timestamptz',
+                           'inclusion': 'available'}},
              {'breadcrumb': ('properties', 'col4'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'timestamp'}},
+                           'sql-datatype': 'timestamp',
+                           'inclusion': 'available'}},
              {'breadcrumb': ('properties', 'col5'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'timestamp with time zone'}}
+                           'sql-datatype': 'timestamp with time zone',
+                           'inclusion': 'available'}}
          ]},
         {'tap_stream_id': 'test-db.public.table2',
          'database_name': 'test-db',
          'table_name': 'public.table2',
-         'key_properties': ['col1', 'col2'],
          'schema': {
              'properties': {
                  'col1': {
@@ -148,7 +153,6 @@ def expected_catalog_from_db():
                      'type': ['null', 'boolean']}},
              'type': 'object'
          },
-         'is_view': False,
          'stream': 'table2',
          'metadata': [
              {'breadcrumb': (),
@@ -156,13 +160,18 @@ def expected_catalog_from_db():
                            'forced-replication-method': {
                             'replication-method': 'FULL_TABLE',
                             'reason': 'No replication keys found from table'
-                           }}},
+                           },
+                           'table-key-properties': ['col1', 'col2'],
+                           'is-view': False,
+                           'schema-name': 'table2'}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'int4'}},
+                           'sql-datatype': 'int4',
+                           'inclusion': 'available'}},
              {'breadcrumb': ('properties', 'col2'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'bool'}}]},
+                           'sql-datatype': 'bool',
+                           'inclusion': 'available'}}]},
         {'tap_stream_id': 'test-db.public.view1',
          'database_name': 'test-db',
          'table_name': 'public.view1',
@@ -175,7 +184,6 @@ def expected_catalog_from_db():
                      'inclusion': 'unsupported',
                      'description': 'Unsupported column type unknown'}},
              'type': 'object'},
-         'is_view': True,
          'stream': 'view1',
          'metadata': [
              {'breadcrumb': (),
@@ -183,13 +191,18 @@ def expected_catalog_from_db():
                            'forced-replication-method': {
                             'replication-method': 'FULL_TABLE',
                             'reason': 'No replication keys found from table'
-                           }}},
+                           },
+                           'table-key-properties': [],
+                           'is-view': True,
+                           'schema-name': 'view1'}},
              {'breadcrumb': ('properties', 'col1'),
               'metadata': {'selected-by-default': True,
-                           'sql-datatype': 'varchar'}},
+                           'sql-datatype': 'varchar',
+                           'inclusion': 'available'}},
              {'breadcrumb': ('properties', 'col2'),
               'metadata': {'selected-by-default': False,
-                           'sql-datatype': 'unknown'}}
+                           'sql-datatype': 'unknown',
+                           'inclusion': 'unsupported'}}
          ]}
     ]})
 

--- a/tests/tap_redshift/test_tap_redshift.py
+++ b/tests/tap_redshift/test_tap_redshift.py
@@ -233,18 +233,29 @@ class TestRedShiftTap(object):
                  'nullable': 'YES'},
                 {'pos': 3, 'name': 'col3', 'type': 'timestamptz',
                  'nullable': 'NO'}]
+        table_name = 'test_table'
+        key_properties = ['col1']
+        is_view = False
         expected_mdata = metadata.new()
         metadata.write(expected_mdata, (), 'selected-by-default', False)
         for col in cols:
+            schema = tap_redshift.schema_for_column(col)
             metadata.write(expected_mdata, (),
                            'valid-replication-keys',
                            ['col3'])
+            metadata.write(expected_mdata, (),
+                           'table-key-properties', key_properties)
+            metadata.write(expected_mdata, (), 'is-view', is_view)
+            metadata.write(expected_mdata, (), 'schema-name', table_name)
             metadata.write(expected_mdata, (
                 'properties', col['name']), 'selected-by-default', True)
             metadata.write(expected_mdata, (
                 'properties', col['name']), 'sql-datatype', col['type'])
+            metadata.write(expected_mdata, (
+                'properties', col['name']), 'inclusion', schema.inclusion)
 
-        actual_mdata = tap_redshift.create_column_metadata(cols)
+        actual_mdata = tap_redshift.create_column_metadata(
+            cols, is_view, table_name, key_properties)
         assert_that(actual_mdata, equal_to(metadata.to_list(expected_mdata)))
 
     def test_type_int4(self):
@@ -296,18 +307,44 @@ class TestRedShiftTap(object):
         expected_schema = stream_schema['schema']['properties']['created_at']
         assert_that(column_schema, equal_to(expected_schema))
 
-    def test_valid_rep_keys(self, discovery_conn, expected_catalog_from_db):
+    def test_table_metadata(self, discovery_conn, expected_catalog_from_db):
         actual_catalog = tap_redshift.discover_catalog(discovery_conn,
                                                        'public')
         for i, actual_entry in enumerate(actual_catalog.streams):
             expected_entry = expected_catalog_from_db.streams[i]
             actual_metadata = metadata.to_map(actual_entry.metadata)
             expected_metadata = metadata.to_map(expected_entry.metadata)
+
             actual_valid_rep_keys = metadata.get(
                 actual_metadata, (), 'valid-replication-keys')
             expected_valid_rep_keys = metadata.get(
                 expected_metadata, (), 'valid-replication-keys')
+
             assert_that(actual_valid_rep_keys,
                         equal_to(expected_valid_rep_keys))
+
+            actual_table_key_properties = metadata.get(
+                actual_metadata, (), 'table-key-properties')
+            expected_table_key_properties = metadata.get(
+                expected_metadata, (), 'table-key-properties')
+
+            assert_that(actual_table_key_properties,
+                        equal_to(expected_table_key_properties))
+
+            actual_schema_name = metadata.get(
+                actual_metadata, (), 'schema-name')
+            expected_schema_name = metadata.get(
+                expected_metadata, (), 'schema-name')
+
+            assert_that(actual_schema_name,
+                        equal_to(expected_schema_name))
+
+            actual_is_view = metadata.get(
+                actual_metadata, (), 'is-view')
+            expected_is_view = metadata.get(
+                expected_metadata, (), 'is-view')
+
+            assert_that(actual_is_view,
+                        equal_to(expected_is_view))
 
         # TODO write tests for full and incremental sync


### PR DESCRIPTION
- Adds `key_properties` and `bookmark_properties` to SCHEMA messages during sync.
- Migrate applicable fields (replication-key, replication-method, is-view, schema-name, inclusion) into metadata.

GH issues:
- #24
- #17 