### PR TITLE
Adding keyword name to isoformat()

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -278,7 +278,7 @@ def row_to_record(catalog_entry, version, row, columns, time_extracted):
     row_to_persist = ()
     for idx, elem in enumerate(row):
         if isinstance(elem, datetime.date):
-            elem = elem.isoformat('T') + 'Z'
+            elem = elem.isoformat(sep='T') + 'Z'
         row_to_persist += (elem,)
     return singer.RecordMessage(
         stream=catalog_entry.stream,


### PR DESCRIPTION
I was getting an error that isoformat('T') does not work. https://docs.python.org/3.2/library/datetime.html says the signature is isoformat(sep='T', timespec='auto')

'T' is the default but I put it in for explicitness. 