### PR TITLE
Fix isoformat(T) bug

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -277,7 +277,7 @@ def get_stream_version(tap_stream_id, state):
 def row_to_record(catalog_entry, version, row, columns, time_extracted):
     row_to_persist = ()
     for idx, elem in enumerate(row):
-        if isinstance(elem, datetime.date):
+        if isinstance(elem, datetime.datetime):
             elem = elem.isoformat('T') + 'Z'
         row_to_persist += (elem,)
     return singer.RecordMessage(


### PR DESCRIPTION
This issue is caused by the line https://github.com/datadotworld/tap-redshift/blob/master/tap_redshift/__init__.py#L280
isoformat('T') only works on datetime objects not date objects.

>>> import datetime
>>> today = datetime.date.today()
>>> today.isoformat()
'2019-04-26'
>>> today.isoformat('T')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: isoformat() takes no arguments (1 given)
>>> now = datetime.datetime.now()
>>> now.isoformat('T')
'2019-04-26T11:56:49.223151'
>>> now.isoformat()
'2019-04-26T11:56:49.223151'