### PR TITLE
Correctly discover columns for given table

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -86,7 +86,9 @@ def discover_catalog(conn, db_schema):
         SELECT c.table_name, c.ordinal_position, c.column_name, c.udt_name,
         c.is_nullable
         FROM INFORMATION_SCHEMA.Tables t
-        JOIN INFORMATION_SCHEMA.Columns c ON c.table_name = t.table_name
+        JOIN INFORMATION_SCHEMA.Columns c
+            ON c.table_name = t.table_name AND
+               c.table_schema = t.table_schema
         WHERE t.table_schema = '{}'
         ORDER BY c.table_name, c.ordinal_position
         """.format(db_schema))


### PR DESCRIPTION
Previously you would get columns from every schema for a given table name. This stops that.