### PR TITLE
Fix Primary key, column and table discovery queries

### DIFF
--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -103,7 +103,7 @@ def discover_catalog(conn, db_schema):
           JOIN pg_catalog.pg_class AS c ON c.oid = con.conrelid
           JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
           JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE schema_name = {} AND contype IN ('p')
+        WHERE schema_name = '{}' AND contype IN ('p')
         ORDER BY
           schema_name,
           table_name,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -95,7 +95,6 @@ def discover_catalog(conn, db_schema):
         conn,
         """
         SELECT
-          n.nspname AS schema_name,
           c.relname AS table_name,
           a.attname AS column_name
         FROM
@@ -103,9 +102,9 @@ def discover_catalog(conn, db_schema):
           JOIN pg_catalog.pg_class AS c ON c.oid = con.conrelid
           JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
           JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE schema_name = '{}' AND contype IN ('p')
+        WHERE n.nspname = '{}' AND contype IN ('p')
         ORDER BY
-          schema_name,
+          n.nspname,
           table_name,
           a.attnum;
         """.format(db_schema))

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -103,7 +103,7 @@ def discover_catalog(conn, db_schema):
           JOIN pg_catalog.pg_class AS c ON c.oid = con.conrelid
           JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
           JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE schema_name = {} contype IN ('p')
+        WHERE schema_name = {} AND contype IN ('p')
         ORDER BY
           schema_name,
           table_name,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -103,7 +103,7 @@ def discover_catalog(conn, db_schema):
           JOIN pg_catalog.pg_class AS c ON c.oid = con.conrelid
           JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
           JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE schema_name in {} contype IN ('p')
+        WHERE schema_name in = {} contype IN ('p')
         ORDER BY
           schema_name,
           table_name,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -109,8 +109,8 @@ def discover_catalog(conn, db_schema):
           table_name,
           a.attnum;
         """.format(db_schema))
-    print("pk_specs: ")
-    print(pk_specs)
+    LOGGER.info("pk_specs: ")
+    LOGGER.info(pk_specs)
     entries = []
     table_columns = [{'name': k, 'columns': [
         {'pos': t[1], 'name': t[2], 'type': t[3],
@@ -119,8 +119,8 @@ def discover_catalog(conn, db_schema):
 
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
-    print("PKs are: ")
-    print(table_pks)
+    LOGGER.info("PKs are: ")
+    LOGGER.info(table_pks)
     table_types = dict(table_spec)
 
     for items in table_columns:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -278,7 +278,7 @@ def get_stream_version(tap_stream_id, state):
 def row_to_record(catalog_entry, version, row, columns, time_extracted):
     row_to_persist = ()
     for idx, elem in enumerate(row):
-        if isinstance(elem, datetime.date):
+        if isinstance(elem, datetime.datetime):
             elem = elem.isoformat('T') + 'Z'
         row_to_persist += (elem,)
     return singer.RecordMessage(

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -103,7 +103,7 @@ def discover_catalog(conn, db_schema):
           JOIN pg_catalog.pg_class AS c ON c.oid = con.conrelid
           JOIN pg_catalog.pg_attribute AS a ON a.attrelid = c.oid AND a.attnum = ANY(con.conkey)
           JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE schema_name in = {} contype IN ('p')
+        WHERE schema_name = {} contype IN ('p')
         ORDER BY
           schema_name,
           table_name,

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -109,7 +109,8 @@ def discover_catalog(conn, db_schema):
           table_name,
           a.attnum;
         """.format(db_schema))
-
+    print("pk_specs: ")
+    print(pk_specs)
     entries = []
     table_columns = [{'name': k, 'columns': [
         {'pos': t[1], 'name': t[2], 'type': t[3],
@@ -118,7 +119,8 @@ def discover_catalog(conn, db_schema):
 
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
-
+    print("PKs are: ")
+    print(table_pks)
     table_types = dict(table_spec)
 
     for items in table_columns:

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -89,6 +89,8 @@ def discover_catalog(conn, db_schema):
         ORDER BY table_name, ordinal_position
         """.format(db_schema))
 
+    LOGGER.info(column_specs)
+
     pk_specs = select_all(
         conn,
         """

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -76,19 +76,17 @@ def discover_catalog(conn, db_schema):
         conn,
         """
         SELECT table_name, table_type
-        FROM INFORMATION_SCHEMA.Tables
+        FROM SVV_TABLES
         WHERE table_schema = '{}'
         """.format(db_schema))
 
     column_specs = select_all(
         conn,
         """
-        SELECT c.table_name, c.ordinal_position, c.column_name, c.udt_name,
-        c.is_nullable
-        FROM INFORMATION_SCHEMA.Tables t
-        JOIN INFORMATION_SCHEMA.Columns c ON c.table_name = t.table_name
-        WHERE t.table_schema = '{}'
-        ORDER BY c.table_name, c.ordinal_position
+        SELECT table_name, ordinal_position, column_name, data_type, is_nullable
+        FROM SVV_COLUMNS
+        WHERE table_schema = '{}'
+        ORDER BY table_name, ordinal_position
         """.format(db_schema))
 
     pk_specs = select_all(

--- a/tap_redshift/__init__.py
+++ b/tap_redshift/__init__.py
@@ -48,18 +48,20 @@ REQUIRED_CONFIG_KEYS = [
     'password',
     'start_date'
 ]
-
 STRING_TYPES = {'char', 'character', 'nchar', 'bpchar', 'text', 'varchar',
                 'character varying', 'nvarchar'}
 
 BYTES_FOR_INTEGER_TYPE = {
     'int2': 2,
+    'smallint': 2,
     'int': 4,
     'int4': 4,
-    'int8': 8
+    'integer': 4,
+    'int8': 8,
+    'bigint': 8
 }
 
-FLOAT_TYPES = {'float', 'float4', 'float8'}
+FLOAT_TYPES = {'float', 'float4', 'float8', 'double precision', 'real'}
 
 DATE_TYPES = {'date'}
 
@@ -89,8 +91,6 @@ def discover_catalog(conn, db_schema):
         ORDER BY table_name, ordinal_position
         """.format(db_schema))
 
-    LOGGER.info(column_specs)
-
     pk_specs = select_all(
         conn,
         """
@@ -108,8 +108,7 @@ def discover_catalog(conn, db_schema):
           table_name,
           a.attnum;
         """.format(db_schema))
-    LOGGER.info("pk_specs: ")
-    LOGGER.info(pk_specs)
+    
     entries = []
     table_columns = [{'name': k, 'columns': [
         {'pos': t[1], 'name': t[2], 'type': t[3],
@@ -118,8 +117,7 @@ def discover_catalog(conn, db_schema):
 
     table_pks = {k: [t[1] for t in v]
                  for k, v in groupby(pk_specs, key=lambda t: t[0])}
-    LOGGER.info("PKs are: ")
-    LOGGER.info(table_pks)
+
     table_types = dict(table_spec)
 
     for items in table_columns:


### PR DESCRIPTION
Current implementation returns empty set. Redshift tables information_schema.table_constraints and information_schema.key_column_usage are empty.